### PR TITLE
fix: hover 상태 스타일 제거

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,9 +6,8 @@ const buttonVariants = cva({
   base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-lg font-bold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:bg-gray-100 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   variants: {
     variant: {
-      default: 'bg-primary-500 text-white hover:bg-primary-600',
-      outline:
-        'bg-white text-primary-500 border border-gray-100 hover:bg-gray-50',
+      default: 'bg-primary-500 text-white',
+      outline: 'bg-white text-primary-500 border border-gray-100',
     },
     size: {
       default: 'px-7 py-3.5',

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -5,7 +5,7 @@ import { cn } from '~/utils/cn'
 import ToggleCheck from '~/assets/svgs/toggle-check.svg?react'
 
 const toggleVariants = cva({
-  base: 'inline-flex group items-center rounded-sm text-lg font-medium text-gray-800 ring-offset-background transition-colors hover:bg-primary-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary-200 gap-2',
+  base: 'inline-flex group items-center rounded-sm text-lg font-medium text-gray-800 ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary-200 gap-2',
   variants: {
     variant: {
       default: 'bg-gray-50',
@@ -37,7 +37,7 @@ function Toggle({ className, variant, size, children, ...props }: ToggleProps) {
 
 function ToggleCheckIcon() {
   return (
-    <ToggleCheck className="text-gray-100 transition-colors group-hover:text-primary-300 group-data-[state=on]:text-primary-500 [&_svg]:pointer-events-none [&_svg]:size-6 [&_svg]:shrink-0" />
+    <ToggleCheck className="text-gray-100 transition-colors group-data-[state=on]:text-primary-500 [&_svg]:pointer-events-none [&_svg]:size-6 [&_svg]:shrink-0" />
   )
 }
 


### PR DESCRIPTION
## Summary

> - closed #9 

_모바일이 주 환경인 것을 고려해 hover 상태일 때 변경되는 CSS 속성을 제거합니다._

## Tasks

- [x] Button
- [x] Toggle
- [x] Toggle Group

## To Reviewer

Toggle Group은 내부적으로 Toggle의 toggleVariants를 사용하고 있기 때문에, Toggle을 변경하면서 함께 적용되었습니다!
