### PR TITLE
fix: remove preinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

_preinstall 스크립트가 vercel 빌드 오류를 발생시켜서 일시적으로 비활성화합니다._
