### PR TITLE
feat: 헤더, 바텀 내비게이션 바 라우팅 기능 추가

### DIFF
--- a/src/components/bottom-navigation-bar.tsx
+++ b/src/components/bottom-navigation-bar.tsx
@@ -1,11 +1,10 @@
+import { useNavigate } from 'react-router-dom'
 import BottomNavigationFloor from '~/assets/svgs/bottom-navigation-floor.svg?react'
 import Home from '~/assets/svgs/home.svg?react'
 
-export interface BottomNavigationBarProps {
-  onClick?: () => void
-}
+function BottomNavigationBar() {
+  const navigate = useNavigate()
 
-function BottomNavigationBar({ onClick }: BottomNavigationBarProps) {
   return (
     <div className="fixed bottom-0 flex h-14 w-full max-w-screen-sm">
       <div className="h-14 w-4/12 flex-1 bg-white" />
@@ -13,10 +12,12 @@ function BottomNavigationBar({ onClick }: BottomNavigationBarProps) {
       <div className="h-14 w-4/12 flex-1 bg-white" />
       <button
         type="button"
-        onClick={onClick}
+        onClick={() => {
+          navigate('/')
+        }}
         className="absolute -bottom-1 left-1/2 flex size-[88px] -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-xl bg-primary-500 shadow-1"
       >
-        <Home className="text-white" />
+        <Home className="size-12 text-white" />
       </button>
     </div>
   )

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom'
+
 import ChevronLeft from '~/assets/svgs/chevron-left.svg?react'
 import Setting from '~/assets/svgs/setting.svg?react'
 
@@ -5,24 +7,24 @@ export interface HeaderProps {
   title?: string
   showGoBackButton?: boolean
   showSettingButton?: boolean
-  onGoBackClick?: () => void
-  onSettingClick?: () => void
 }
 
 function Header({
   title,
   showGoBackButton = false,
   showSettingButton = false,
-  onGoBackClick,
-  onSettingClick,
 }: HeaderProps) {
+  const navigate = useNavigate()
+
   return (
     <header className="fixed top-0 z-50 flex h-16 w-full max-w-screen-sm items-center justify-between border-b border-gray-50 bg-white px-2.5 py-6">
       <div className="w-10">
         {showGoBackButton && (
           <button
             type="button"
-            onClick={onGoBackClick}
+            onClick={() => {
+              navigate(-1)
+            }}
             className="flex h-10 w-10 items-center justify-center"
           >
             <ChevronLeft />
@@ -36,7 +38,9 @@ function Header({
         {showSettingButton && (
           <button
             type="button"
-            onClick={onSettingClick}
+            onClick={() => {
+              navigate('/settings')
+            }}
             className="flex h-10 w-10 items-center justify-center"
           >
             <Setting />


### PR DESCRIPTION
## Summary

> closed #36 

* 뒤로 가기 버튼을 누르면 뒤로 가고 설정 버튼을 누르면 설정 페이지로 이동합니다.
* 바텀 내비게이션 바의 홈 아이콘 크기를 키웁니다.

## Tasks

- [x] 헤더 라우팅 기능 추가
- [x] 바텀 내비게이션 바 홈 아이콘 확대